### PR TITLE
Already promisified functions must not be re-promisified

### DIFF
--- a/lib/promisify.js
+++ b/lib/promisify.js
@@ -15,6 +15,8 @@
 
 "use strict";
 
+var IS_PROMISIFIED_PROP = '__isPromisified__';
+
 var Promise;
 
 // Get a promise object. This may be native, or it may be polyfilled
@@ -54,9 +56,20 @@ function callback() {
     }
 }
 
-module.exports = function (original, custom) {
+function isPromisified(fn) {
+    try {
+        return fn[IS_PROMISIFIED_PROP] === true;
+    } catch (e) {
+        return false;
+    }
+}
 
-    return function () {
+module.exports = function (original, custom) {
+    if (isPromisified(original)) {
+        return original;
+    }
+
+    var fn = function () {
 
         // Store original context
         var that = this,
@@ -75,4 +88,13 @@ module.exports = function (original, custom) {
             original.apply(that, args);
         });
     };
+
+    Object.defineProperty(fn, IS_PROMISIFIED_PROP, {
+        value: true,
+        configurable: false,
+        enumerable: false,
+        writable: false
+    });
+
+    return fn;
 };

--- a/tests/promisify-tests.js
+++ b/tests/promisify-tests.js
@@ -269,5 +269,12 @@ module.exports = {
         promisified().then(function (result) {
             test.deepEqual(result, [1, 2, 3], "Unexpected result array");
         }).then(test.done);
+    },
+
+    "already promisified functions must not be re-promisified": function (test) {
+        var promisified = promisify(standard);
+        var rePromisified = promisify(promisified);
+        test.strictEqual(promisified, rePromisified);
+        test.done();
     }
 };


### PR DESCRIPTION
i.e., `promisify(promisify(fn))` promisifies only once.