### PR TITLE
Use `apply` to call the original function

### DIFF
--- a/lib/promisify.js
+++ b/lib/promisify.js
@@ -56,7 +56,7 @@ function promisify(original) {
             });
 
             // Call the function.
-            original.call(this, ...args);
+            original.apply(this, args);
         });
     };
 }


### PR DESCRIPTION
This avoids the extra step of spreading the arguments array since `Function.prototype.apply` does the same as `Function.prototype.call` but takes the arguments in the form of an array, which we already have. It also makes the code a little simpler.